### PR TITLE
Override parent props

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepublish": "npm test && npm run dist",
     "dist": "rm -rf dist/ && mkdir -p dist/ && tsc --project src/tsconfig.json",
     "tests": "jest",
-    "lint": "tslint --project tsconfig.json --type-check '{ts,tests,src}/**/*.{ts,tsx}'",
+    "lint": "tslint --project tsconfig.json '{ts,tests,src}/**/*.{ts,tsx}'",
     "test": "npm run lint && npm run tests -- --coverage"
   },
   "repository": {
@@ -53,8 +53,8 @@
     "react-dom": "15.5.4",
     "react-test-renderer": "15.5.4",
     "ts-jest": "20.0.3",
-    "tslint": "5.1.0",
-    "tslint-config-dabapps": "github:dabapps/tslint-config-dabapps"
+    "tslint": "5.8.0",
+    "tslint-config-dabapps": "github:dabapps/tslint-config-dabapps#v0.4.0"
   },
   "peerDependencies": {
     "react": ">= 15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/react-set-props",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Store arbitrary state in redux with a similar API to setState",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,9 +110,9 @@ export function withSetProps<
     const storeProps = props[id];
 
     return {
-      ...storeProps,
       // TODO: Remove casts when TS supports destructing extended types
-      ...parentProps as any
+      ...parentProps as any,
+      ...storeProps,
     };
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,7 +57,7 @@ export function clearPropsAction(id: string) {
   return {
     type: CLEAR_PROPS,
     payload: {
-      id
+      id,
     },
   };
 }
@@ -76,7 +76,7 @@ export function setPropsReducer(
           ...previous,
           ...action.payload.props,
         },
-        __secretKey: SET_PROPS_SECRET_KEY
+        __secretKey: SET_PROPS_SECRET_KEY,
       };
     case CLEAR_PROPS:
       const clearedState = {...state};
@@ -85,7 +85,7 @@ export function setPropsReducer(
 
       return {
         ...clearedState,
-        __secretKey: SET_PROPS_SECRET_KEY
+        __secretKey: SET_PROPS_SECRET_KEY,
       };
     default:
       return state;
@@ -121,7 +121,7 @@ export function withSetProps<
       (state, props: OwnProps): OwnProps => props,
       {
         __setProps: setPropsAction,
-        __clearProps: clearPropsAction
+        __clearProps: clearPropsAction,
       }
     )
     (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ const SET_PROPS = 'SET_PROPS';
 const CLEAR_PROPS = 'CLEAR_PROPS';
 const SET_PROPS_SECRET_KEY = 'SET_PROPS_SECRET_KEY';
 
-type Component<P> = React.ComponentClass<P> | React.StatelessComponent<P>;
+type ComponentType<P> = React.ComponentClass<P> | React.StatelessComponent<P>;
 
 export interface StringKeyedObject {
   [index: string]: any;
@@ -94,7 +94,7 @@ export function setPropsReducer(
 
 export function withSetProps<
   Props extends StringKeyedObject,
-  ExternalProps extends StringKeyedObject = StringKeyedObject
+  OwnProps extends StringKeyedObject = StringKeyedObject
 >(getInitialProps: (props: StringKeyedObject) => Props) {
 
   const unconnected = (id: string) =>
@@ -116,21 +116,21 @@ export function withSetProps<
     };
   });
 
-  return (Component: Component<SetPropsInterface<Props> & ExternalProps>) => {
+  return (Component: ComponentType<SetPropsInterface<Props> & OwnProps>) => {
     return connect(
-      (state, props: ExternalProps): ExternalProps => props,
+      (state, props: OwnProps): OwnProps => props,
       {
         __setProps: setPropsAction,
         __clearProps: clearPropsAction
       }
     )
     (
-      class SetPropsWrapper extends React.PureComponent<InternalSetPropsInterface<Props> & ExternalProps, void> {
+      class SetPropsWrapper extends React.PureComponent<InternalSetPropsInterface<Props> & OwnProps, void> {
         private __id: string; // tslint:disable-line:variable-name
-        private Connected: Component<SetPropsInterface<Props>>;
+        private Connected: ComponentType<SetPropsInterface<Props>>;
 
         public constructor(
-          inputProps: InternalSetPropsInterface<Props> & ExternalProps
+          inputProps: InternalSetPropsInterface<Props> & OwnProps
         ) {
           super(inputProps);
 

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -8,7 +8,7 @@ import {
   setPropsAction,
   SetPropsInterface,
   setPropsReducer,
-  withSetProps
+  withSetProps,
 } from '../src/';
 
 describe('Set Props', () => {
@@ -27,6 +27,7 @@ describe('Set Props', () => {
     return (
       <p>
         Count: {count}
+        {/* tslint:disable-next-line:jsx-no-lambda */}
         <button onClick={() => setProps({count: count + 1})}>
           {buttonText}
         </button>
@@ -35,7 +36,7 @@ describe('Set Props', () => {
   };
 
   const getInitialProps = () => ({
-    count: 0
+    count: 0,
   });
 
   const SetPropsCounter = withSetProps<Props, ExternalProps>(getInitialProps)(Counter);
@@ -84,8 +85,8 @@ describe('Set Props', () => {
 
       expect(testStore.getState()).toEqual({
         setPropsReducer: {
-          __secretKey: 'SET_PROPS_SECRET_KEY'
-        }
+          __secretKey: 'SET_PROPS_SECRET_KEY',
+        },
       });
 
       expect(Object.keys((testStore.getState() as any).setPropsReducer).length).toEqual(1);
@@ -115,8 +116,8 @@ describe('Set Props', () => {
 
       expect(testStore.getState()).toEqual({
         setPropsReducer: {
-          __secretKey: 'SET_PROPS_SECRET_KEY'
-        }
+          __secretKey: 'SET_PROPS_SECRET_KEY',
+        },
       });
 
       expect(Object.keys((testStore.getState() as any).setPropsReducer).length).toEqual(1);
@@ -133,8 +134,8 @@ describe('Set Props', () => {
 
       expect(testStore.getState()).toEqual({
         setPropsReducer: {
-          __secretKey: 'SET_PROPS_SECRET_KEY'
-        }
+          __secretKey: 'SET_PROPS_SECRET_KEY',
+        },
       });
 
       const props = (testStore.getState() as any).setPropsReducer;
@@ -165,7 +166,7 @@ describe('Set Props', () => {
       state = setPropsReducer(undefined, {type: 'Unknown'} as any);
 
       expect(state).toEqual({
-        __secretKey: 'SET_PROPS_SECRET_KEY'
+        __secretKey: 'SET_PROPS_SECRET_KEY',
       });
     });
 
@@ -175,8 +176,8 @@ describe('Set Props', () => {
       expect(state).toEqual({
         __secretKey: 'SET_PROPS_SECRET_KEY',
         id: {
-          foo: 'bar'
-        }
+          foo: 'bar',
+        },
       });
 
       state = setPropsReducer(state, setPropsAction('id2', {foo: 'bar'}));
@@ -184,11 +185,11 @@ describe('Set Props', () => {
       expect(state).toEqual({
         __secretKey: 'SET_PROPS_SECRET_KEY',
         id: {
-          foo: 'bar'
+          foo: 'bar',
         },
         id2: {
-          foo: 'bar'
-        }
+          foo: 'bar',
+        },
       });
     });
 
@@ -199,11 +200,11 @@ describe('Set Props', () => {
         __secretKey: 'SET_PROPS_SECRET_KEY',
         id: {
           foo: undefined,
-          baz: 'foo'
+          baz: 'foo',
         },
         id2: {
-          foo: 'bar'
-        }
+          foo: 'bar',
+        },
       });
     });
 
@@ -213,14 +214,14 @@ describe('Set Props', () => {
       expect(state).toEqual({
         __secretKey: 'SET_PROPS_SECRET_KEY',
         id2: {
-          foo: 'bar'
-        }
+          foo: 'bar',
+        },
       });
 
       state = setPropsReducer(state, clearPropsAction('id2'));
 
       expect(state).toEqual({
-        __secretKey: 'SET_PROPS_SECRET_KEY'
+        __secretKey: 'SET_PROPS_SECRET_KEY',
       });
     });
 


### PR DESCRIPTION
By reordering the precedence of the store vs parent props we allow users to pass initial props from the parent, and override them with `setProps`.

```typescript
<Counter count={INITIAL_VALUE} />
```

```typescript
function getInitialProps ({ count }: OwnProps) {
  return {
    count
  };
}
```

```typescript
this.props.setProps({
  count: count + 1
});
```

This PR additionally pins & updates our tsconfig.